### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           region: ${{ secrets.AWS_REGION }}
       - name: Build image and publish it to staging registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: 521664337176.dkr.ecr.us-east-1.amazonaws.com/application
           username: ${{ steps.ecr.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore